### PR TITLE
Unit test fixes

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -47,9 +47,9 @@ define cron::fragment (
   include ::cron
 
   validate_re($ensure_real, '^(absent|file|present)$', "cron::fragment::ensure is ${ensure} and must be absent, file or present")
-  if is_string($content_real) == false { fail('cron::fragment::content must be a string') }
-  if is_string($owner) == false { fail('cron::fragment::owner must be a string') }
-  if is_string($group) == false { fail('cron::fragment::group must be a string') }
+  if is_string($content_real) == false { fail('cron::fragment::content is not a string') }
+  if is_string($owner) == false { fail('cron::fragment::owner is not a string') }
+  if is_string($group) == false { fail('cron::fragment::group is not a string') }
   validate_re($mode_real, '^[0-7]{4}$',
     "cron::fragment::mode is <${mode_real}> and must be a valid four digit mode in octal notation.")
 

--- a/manifests/user/crontab.pp
+++ b/manifests/user/crontab.pp
@@ -80,7 +80,7 @@ define cron::user::crontab (
   validate_re($mode, '^[0-7]{4}$', "cron::fragment::mode is <${mode}> and must be a valid four digit mode in octal notation.")
 
   $content_real = $content ? {
-    undef   => "template('cron/crontab.erb')",
+    undef   => template('cron/crontab.erb'),
     default => $content,
   }
 

--- a/manifests/user/crontab.pp
+++ b/manifests/user/crontab.pp
@@ -59,7 +59,7 @@ define cron::user::crontab (
   }
 
   if $content != undef and is_string($content) == false {
-    fail('cron::user::crontab::content must be a string')
+    fail('cron::user::crontab::content is not a string')
   }
 
   if $entries != undef {
@@ -72,8 +72,8 @@ define cron::user::crontab (
     $crontab_vars = $vars
   }
 
-  if is_string($owner) == false { fail('cron::user::crontab::owner must be a string') }
-  if is_string($group) == false { fail('cron::user::crontab::group must be a string') }
+  if is_string($owner) == false { fail('cron::user::crontab::owner is not a string') }
+  if is_string($group) == false { fail('cron::user::crontab::group is not a string') }
 
   validate_absolute_path($path_real)
   validate_re($ensure, '^(absent|file|present)$', "cron::fragment::ensure is ${ensure} and must be absent, file or present")

--- a/spec/defines/crontab_spec.rb
+++ b/spec/defines/crontab_spec.rb
@@ -56,17 +56,17 @@ describe 'cron::user::crontab' do
           :mode    => '0242',
         }
       end
-      
-      it {
+
+      it do
         should contain_file('/var/spool/cron/operator').with({
           'ensure'  => 'file',
           'owner'   => 'operator',
           'group'   => 'operator',
           'mode'    => '0242',
         })
-      }      
+      end
     end
-    
+
     context 'with entries set' do
       let (:params) do
         {
@@ -77,11 +77,11 @@ describe 'cron::user::crontab' do
           :content => "# Echo Hello World\n* 1 * * * $MYECHO \"Hello World!\" 2>&1", 
         }
       end
-      
+
       it { should contain_file('/var/spool/cron/operator').with_content("# Echo Hello World\n* 1 * * * $MYECHO \"Hello World!\" 2>&1") }
-      
+
     end
-    
+
     context 'with vars set' do
       let (:params) do
         {
@@ -92,10 +92,10 @@ describe 'cron::user::crontab' do
           :content => 'SHELL=/bin/bash',
         }
       end
-      
+
       it { should contain_file('/var/spool/cron/operator').with_content("SHELL=/bin/bash") }    
-    end      
-  end      
+    end
+  end
 
   describe 'variable type and content validations' do
     validations = {
@@ -153,5 +153,4 @@ describe 'cron::user::crontab' do
       end # var[:name].each
     end # validations.sort.each
   end # describe 'variable type and content validations'
-
 end

--- a/spec/defines/crontab_spec.rb
+++ b/spec/defines/crontab_spec.rb
@@ -60,4 +60,61 @@ describe 'cron::user::crontab' do
     end      
   end      
 
+  describe 'variable type and content validations' do
+    validations = {
+      'absolute_path' => {
+        :name    => %w(path),
+        :valid   => %w(/absolute/filepath /absolute/directory/),
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, false, nil],
+        :message => 'is not an absolute path',
+      },
+      'hash' => {
+        :name    => %w(entries vars),
+        :valid   => [], # valid hashes are to complex for generic testing
+        :invalid => ['string', 3, 2.42, %w(array), false, nil],
+        :message => 'is not a Hash',
+      },
+      'regex_ensure' => {
+        :name    => %w(ensure),
+        :valid   => %w(absent file present),
+        :invalid => ['string', %w[array], { 'ha' => 'sh' }, 3, 2.42, false, nil],
+        :message => '(must be absent, file or present)',
+      },
+      'regex_mode' => {
+        :name    => %w(mode),
+        :valid   => %w(0755 0644 1755 0242),
+        :invalid => ['string', '755', 980, '0980', %w(array), { 'ha' => 'sh' }, 3, 2.42, false, nil],
+        :message => 'must be a valid four digit mode in octal notation',
+      },
+      'string' => {
+        :name    => %w(content group owner),
+        :valid   => ['string'],
+        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, false],
+        :message => 'is not a string',
+      },
+    }
+
+    validations.sort.each do |type, var|
+      mandatory_params = {} if mandatory_params.nil?
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid, }].reduce(:merge) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid, }].reduce(:merge) }
+            it 'should fail' do
+              expect { should contain_class(subject) }.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
+
 end

--- a/spec/defines/crontab_spec.rb
+++ b/spec/defines/crontab_spec.rb
@@ -9,6 +9,43 @@ describe 'cron::user::crontab' do
     }
   end
 
+  crontab_default = <<-END.gsub(/^\s+\|/, '')
+    |# This file is being maintained by Puppet.
+    |# DO NOT EDIT
+    |
+    |SHELL=/bin/bash
+    |PATH=/sbin:/bin:/usr/sbin:/usr/bin
+    |MAILTO=root
+    |HOME=/
+    |# For details see man 4 crontabs
+    |
+    |# Example of job definition:
+    |# .---------------- minute (0 - 59)
+    |# |  .------------- hour (0 - 23)
+    |# |  |  .---------- day of month (1 - 31)
+    |# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+    |# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+    |# |  |  |  |  |
+    |# *  *  *  *  * user-name command to be executed
+    |
+  END
+
+  context 'with default values for parameters on valid osfamily RedHat' do
+    it { should compile.with_all_deps }
+    it { should contain_class('cron') }
+
+    it do
+      should contain_file('/var/spool/cron/operator').with({
+        'ensure'  => 'file',
+        'owner'   => 'operator',
+        'group'   => 'operator',
+        'mode'    => '0600',
+        'content' => crontab_default,
+        'require' => 'File[crontab]',
+      })
+    end
+  end
+
   context 'with parameters set' do
     context 'when ensure, owner, group and mode are set' do
       let (:params) do

--- a/spec/defines/crontab_spec.rb
+++ b/spec/defines/crontab_spec.rb
@@ -46,55 +46,46 @@ describe 'cron::user::crontab' do
     end
   end
 
-  context 'with parameters set' do
-    context 'when ensure, owner, group and mode are set' do
-      let (:params) do
-        {
-          :ensure  => 'file',
-          :owner   => 'operator',
-          :group   => 'operator',
-          :mode    => '0242',
-        }
-      end
-
-      it do
-        should contain_file('/var/spool/cron/operator').with({
-          'ensure'  => 'file',
-          'owner'   => 'operator',
-          'group'   => 'operator',
-          'mode'    => '0242',
-        })
-      end
+  %w(absent file present).each do |value|
+    context "with ensure set to valid string #{value}" do
+      let(:params) { { :ensure => value } }
+      it {  should contain_file('/var/spool/cron/operator').with_ensure(value) }
     end
+  end
 
-    context 'with entries set' do
-      let (:params) do
-        {
-          :ensure  => 'file',
-          :owner   => 'operator',
-          :group   => 'operator',
-          :mode    => '0242',
-          :content => "# Echo Hello World\n* 1 * * * $MYECHO \"Hello World!\" 2>&1", 
-        }
-      end
+  context 'with owner set to valid string spectester' do
+    let(:params) { { :owner => 'spectester' } }
+    it {  should contain_file('/var/spool/cron/operator').with_owner('spectester') }
+  end
 
-      it { should contain_file('/var/spool/cron/operator').with_content("# Echo Hello World\n* 1 * * * $MYECHO \"Hello World!\" 2>&1") }
+  context 'with group set to valid string spectester' do
+    let(:params) { { :group => 'spectester' } }
+    it {  should contain_file('/var/spool/cron/operator').with_group('spectester') }
+  end
 
-    end
+  context 'with mode set to valid string 0242' do
+    let(:params) { { :mode => '0242' } }
+    it {  should contain_file('/var/spool/cron/operator').with_mode('0242') }
+  end
 
-    context 'with vars set' do
-      let (:params) do
-        {
-          :ensure  => 'file',
-          :owner   => 'operator',
-          :group   => 'operator',
-          :mode    => '0242',
-          :content => 'SHELL=/bin/bash',
-        }
-      end
+  context 'with path set to valid string /test' do
+    let(:params) { { :path => '/test' } }
+    it {  should contain_file('/test/operator') }
+  end
 
-      it { should contain_file('/var/spool/cron/operator').with_content("SHELL=/bin/bash") }    
-    end
+  context 'with content set to valid string #test' do
+    let(:params) { { :content => '#test' } }
+    it {  should contain_file('/var/spool/cron/operator').with_content('#test') }
+  end
+
+  context 'with vars set to valid hash that set two variables' do
+    let(:params) { { :vars => {'SHELL' => '/bin/sh','MAILTO' => 'tester' } } }
+    it { should contain_file('/var/spool/cron/operator').with_content(/^# DO NOT EDIT[\s\S]*MAILTO=tester\nSHELL=\/bin\/sh\n# For details see man 4 crontabs/) }
+  end
+
+  context 'with entries set to a valid hash that will create two tasks' do
+    let (:params) { { :entries => {'spec' => ['0 0 2 4 2 root /bin/true','1 2 3 4 5 root /bin/false'],'test' => ['5 4 3 2 1 spec /bin/test$'] } } }
+    it { should contain_file('/var/spool/cron/operator').with_content(/^# Example of job definition:[\s\S]*# spec\n0 0 2 4 2 root \/bin\/true\n1 2 3 4 5 root \/bin\/false\n# test\n5 4 3 2 1 spec \/bin\/test/) }
   end
 
   describe 'variable type and content validations' do

--- a/spec/defines/fragment_spec.rb
+++ b/spec/defines/fragment_spec.rb
@@ -115,7 +115,7 @@ describe 'cron::fragment' do
         :name    => ['content','owner','group'],
         :valid   => ['valid'],
         :invalid => [['array'],a={'ha'=>'sh'},3,2.42,true,false],
-        :message => 'must be a string',
+        :message => 'is not a string',
       },
     }
 


### PR DESCRIPTION
Refactoring of the unit tests
- atomic tests for each parameter
- added variable type validations
- added tests for OS family depended deviations.
- $ensure parameter doesn't add functionality yet. Have added test cases for it already. Need code fix.
- aligned the error messages with the output of stdlib

Used atomic commits for better readability, will need to squash them once we are done.